### PR TITLE
Change MSR partition size to 16MB

### DIFF
--- a/Source/Deployer.Lumia/LumiaDisklayoutPreparer.cs
+++ b/Source/Deployer.Lumia/LumiaDisklayoutPreparer.cs
@@ -15,7 +15,7 @@ namespace Deployer.Lumia
         private readonly IWindowsOptionsProvider optionsProvider;
         private readonly IEnumerable<ISpaceAllocator<IPhone>> spaceAllocators;
         private readonly IPhone phone;
-        private static readonly ByteSize ReservedPartitionSize = ByteSize.FromMegaBytes(200);
+        private static readonly ByteSize ReservedPartitionSize = ByteSize.FromMegaBytes(16);
         private static readonly ByteSize BootPartitionSize = ByteSize.FromMegaBytes(100);
         private const string BootPartitionLabel = "BOOT";
         private const string WindowsPartitonLabel = "WindowsARM";


### PR DESCRIPTION
Accroding to [Microsoft Docs](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions), beginning in Windows 10, the size of the MSR is 16 MB.
