### PR TITLE
Fix black screen with Dual Boot disabled

### DIFF
--- a/Source/Deployer.Lumia/BcdConfigurator.cs
+++ b/Source/Deployer.Lumia/BcdConfigurator.cs
@@ -59,7 +59,7 @@ namespace Deployer.Lumia
         
         private Guid CreateBootShim()
         {
-            var invokeText = invoker.Invoke(@"/create /d ""Windows 10"" /application BOOTAPP");
+            var invokeText = invoker.Invoke($@"/create {{7619dcca-fafe-11d9-b411-000476eba25f}} /d ""Windows 10"" /application BOOTAPP");
             return FormattingUtils.GetGuid(invokeText);
         }
     }

--- a/Source/Deployer.Lumia/BcdConfigurator.cs
+++ b/Source/Deployer.Lumia/BcdConfigurator.cs
@@ -19,14 +19,17 @@ namespace Deployer.Lumia
         public void SetupBcd()
         {
             var bootShimEntry = CreateBootShim();
+            var dummyEntry = Guid.Parse("7619dcc9-fafe-11d9-b411-000476eba25f");;
             SetupBootShim(bootShimEntry);
+            SetupDummyLoader(dummyEntry);
             SetupBootMgr();
-            SetDisplayOptions(bootShimEntry);
+            SetDisplayOptions(bootShimEntry, dummyEntry);
         }
 
-        private void SetDisplayOptions(Guid entry)
+        private void SetDisplayOptions(Guid entry, Guid dummy)
         {
             invoker.Invoke($@"/displayorder {{{entry}}}");
+            invoker.Invoke($@"/displayorder {{{dummy}}} /addfirst");
             invoker.Invoke($@"/default {{{entry}}}");
             invoker.Invoke($@"/timeout 30");
         }
@@ -38,7 +41,13 @@ namespace Deployer.Lumia
             invoker.Invoke($@"/set {{{guid}}} testsigning on");
             invoker.Invoke($@"/set {{{guid}}} nointegritychecks on");
         }
-
+        
+        private void SetupDummyLoader(Guid guid)
+        {
+            invoker.Invoke($@"/set {{{guid}}} path dummy");
+            invoker.Invoke($@"/set {{{guid}}} description ""Dummy, please ignore""");
+        }
+        
         private void SetupBootMgr()
         {
             invoker.Invoke($@"/set {{bootmgr}} displaybootmenu on");

--- a/Source/Deployer.Lumia/Phone.cs
+++ b/Source/Deployer.Lumia/Phone.cs
@@ -15,6 +15,7 @@ namespace Deployer.Lumia
     {
         private const string WindowsSystem32BootWinloadEfi = @"windows\system32\boot\winload.efi";
         private static readonly Guid WinPhoneBcdGuid = Guid.Parse("7619dcc9-fafe-11d9-b411-000476eba25f");
+        private static readonly Guid WoaBcdGuid = Guid.Parse("7619dcca-fafe-11d9-b411-000476eba25f");
 
         private static readonly ByteSize MinimumPhoneDiskSize = ByteSize.FromGigaBytes(28);
         private static readonly ByteSize MaximumPhoneDiskSize = ByteSize.FromGigaBytes(34);
@@ -176,7 +177,7 @@ namespace Deployer.Lumia
             var containsWinLoad = result.Contains(WindowsSystem32BootWinloadEfi, StringComparison.CurrentCultureIgnoreCase);
             var containsWinPhoneBcdGuid = result.Contains(WinPhoneBcdGuid.ToString(), StringComparison.InvariantCultureIgnoreCase);
 
-            return containsWinLoad ||containsWinPhoneBcdGuid;
+            return containsWinLoad && containsWinPhoneBcdGuid;
         }
 
         private async Task EnableDualBoot()
@@ -188,7 +189,7 @@ namespace Deployer.Lumia
 
             var invoker = await GetBcdInvoker();
             invoker.Invoke($@"/set {{{WinPhoneBcdGuid}}} description ""Windows 10 Phone""");
-            invoker.Invoke($@"/displayorder {{{WinPhoneBcdGuid}}} /addfirst");
+            invoker.Invoke($@"/set {{{WinPhoneBcdGuid}}} path ""\windows\system32\boot\winload.efi""");
             invoker.Invoke($@"/default {{{WinPhoneBcdGuid}}}");
 
             Log.Verbose("Dual Boot enabled");
@@ -202,8 +203,9 @@ namespace Deployer.Lumia
             await systemPartition.SetGptType(PartitionType.Esp);
 
             var invoker = await GetBcdInvoker();
-            var result = invoker.Invoke($@"/displayorder {{{WinPhoneBcdGuid}}} /remove");
-
+            invoker.Invoke($@"/set {{{WinPhoneBcdGuid}}} description ""Dummy, please ignore""");
+            invoker.Invoke($@"/set {{{WinPhoneBcdGuid}}} path ""dummy""");
+            invoker.Invoke($@"/default {{{WoaBcdGuid}}}");
             Log.Verbose("Dual Boot disabled");
         }
 


### PR DESCRIPTION
Leave a dummy, nonfunctional W10M loader in place, to allow the boot menu to show in recent W10M builds.